### PR TITLE
Melhoria - Ignorando erro do certificado digital

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,8 @@ module.exports = {
       requests.post({
           headers: headers,
           url: 'https://sinespcidadao.sinesp.gov.br/sinesp-cidadao/mobile/consultar-placa',
-          body: xml
+          body: xml,
+          strictSSL: false
         }, function(error, response, body){
 
           if (error===null) {


### PR DESCRIPTION
Boa Noite

Há algum tempo tenho tomado erro referente ao certificado digital na API, o mesmo acontece ao acessar o site da Sinesp, realizei uma pequena alteração no request e o erro não ocorre mais.