### PR TITLE
Adicionado um novo parametro ao callback de retorno da "consultaPlaca" para permetir o uso do promissfy

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@ module.exports = {
             }, function (err, result) {
               resultado = result['soap:Envelope']['soap:Body']['ns2:getStatusResponse']['return'];
             });
-            callback(resultado);
+            callback(null, resultado);
 
           } else {
             callback({ error: error });


### PR DESCRIPTION
Conforme a especificação do Node.JS 8.0 

Pra usar o util.promisify a função callback tem que estar no "error first callback".

https://nodejs.org/dist/latest-v8.x/docs/api/util.html#util_util_promisify_original

 E como no padrão atual o callback só tinha um parametro, apos usar o util.promisify, a promisse sempre era rejeitada.
